### PR TITLE
Add GitHub Actions composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,46 @@
+name: 'Deploy to Posit Connect'
+description: 'Deploy content to Posit Connect using with-connect'
+inputs:
+  connect-license:
+    description: 'Posit Connect license key'
+    required: true
+  connect-version:
+    description: 'Posit Connect version to use'
+    required: false
+    default: '2025.09.0'
+  config-file:
+    description: 'Path to optional rstudio-connect.gcfg configuration file'
+    required: false
+  command:
+    description: 'Command to run against Connect'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout with-connect
+      uses: actions/checkout@v5
+      with:
+        repository: tdstein/with-connect
+        ref: ${{ github.action_ref }}
+        path: .with-connect-action
+    
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+    
+    - name: Install with-connect
+      shell: bash
+      run: uv pip install --system .with-connect-action
+    
+    - name: Create license file
+      shell: bash
+      run: echo "${{ inputs.connect-license }}" > rstudio-connect.lic
+    
+    - name: Deploy to Connect
+      shell: bash
+      run: |
+        ARGS="--version ${{ inputs.connect-version }}"
+        if [ -n "${{ inputs.config-file }}" ]; then
+          ARGS="$ARGS --config ${{ inputs.config-file }}"
+        fi
+        with-connect $ARGS -- ${{ inputs.command }}


### PR DESCRIPTION
Summary: Creates a composite action that simplifies deploying to Posit Connect in GitHub Actions workflows.

Before, users needed multiple steps to set up Python, install dependencies, create license file, and run commands.

After, users can simply use:
  - uses: tdstein/with-connect@v1
    with:
      connect-license: ${{ secrets.CONNECT_LICENSE }}
      command: 'rsconnect deploy manifest .'

Features:
- Automatically checks out with-connect at the specified ref
- Sets up uv and Python environment
- Installs with-connect and all dependencies
- Creates license file from secret
- Runs specified command with proper environment variables

Inputs:
- connect-license (required): Posit Connect license key
- connect-version (optional): Connect version (default: 2025.09.0)
- config-file (optional): Path to rstudio-connect.gcfg configuration file
- command (required): Command to run against Connect

🤖 Generated with Claude Code (https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>